### PR TITLE
Ensure FotoSorter GUI starts after folder selection

### DIFF
--- a/fotosorter.py
+++ b/fotosorter.py
@@ -82,7 +82,6 @@ class FotoSorterApp:
         self.option2_button = tk.Button(self.button_frame, text="", width=20)
         self.option2_button.pack(side=tk.LEFT, padx=5)
         self._next_image()
-        self.root.mainloop()
 
     def _next_image(self):
         if not self.images:
@@ -150,4 +149,5 @@ class FotoSorterApp:
         return self.processed
 
 if __name__ == "__main__":
-    FotoSorterApp()
+    app = FotoSorterApp()
+    app.root.mainloop()


### PR DESCRIPTION
## Summary
- start Tkinter main loop after creating `FotoSorterApp`
- remove extra `mainloop()` call from `_setup_sort_window`

## Testing
- `xvfb-run -a python - <<'PY'
import fotosorter
from unittest import mock

with mock.patch('tkinter.filedialog.askdirectory', side_effect=['test_src','test_dest']), \
     mock.patch('tkinter.messagebox.askyesno', return_value=False):
    app = fotosorter.FotoSorterApp()
    app.root.after(100, app.root.destroy)
    app.root.mainloop()
    print('finished')
PY`
- `python -m py_compile fotosorter.py`


------
https://chatgpt.com/codex/tasks/task_e_688d71e8176883339a66b9cc0207f961